### PR TITLE
Avoid error when .editorconfig is not found

### DIFF
--- a/autoload/editorconfig.vim
+++ b/autoload/editorconfig.vim
@@ -186,6 +186,7 @@ function! editorconfig#init(...)
   let config.global    = {}
   let config.glob_list = []
   let config.globs     = {}
+  let root             = ''
 
   for f in findfile(".editorconfig", path . ';', -1)
     try


### PR DESCRIPTION
Without this we get an error `Undefined variable: root` when editing a file which doesn't have a .editorconfig in any parent folder
